### PR TITLE
Suspense로 감싸지지 않은 useQuery 수정

### DIFF
--- a/server/render/render.tsx
+++ b/server/render/render.tsx
@@ -1,6 +1,7 @@
 import type { Request, Response } from 'express'
 import path from 'path'
 import { ChunkExtractor } from '@loadable/server'
+import { isAxiosError } from 'axios'
 import { renderToString } from 'react-dom/server'
 import { Helmet } from 'react-helmet'
 import { StaticRouter } from 'react-router-dom/server'
@@ -31,7 +32,13 @@ export default async function renderHome(url: string, req: Request, res: Respons
       })
     } catch (error) {
       console.error(error)
-      return res.status(404).send('<h1>NOT FOUND</h1>')
+      if (isAxiosError(error)) {
+        if (error.response?.status !== 400) {
+          return res.status(404).send('<h1>NOT FOUND</h1>')
+        }
+      } else {
+        return res.status(500).send('<h1>INTERNAL SERVER ERROR</h1>')
+      }
     }
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Layout } from 'antd'
+import { Suspense } from 'react'
 import { Outlet } from 'react-router-dom'
 import { ToastContainer } from 'react-toastify'
 import styles from './App.module.scss'
@@ -15,7 +16,9 @@ export default function App() {
       <ToastContainer />
       <Layout>
         <Layout.Content className={styles.layout}>
-          <Outlet />
+          <Suspense>
+            <Outlet />
+          </Suspense>
         </Layout.Content>
       </Layout>
     </div>


### PR DESCRIPTION
# 요약

다음 이슈를 해결했습니다.

- #14 

에러가 나는 원인으로 다음 두 가지를 해결했습니다.

- Suspense가 감싸지지 않은 useQuery 해결
- 백엔드 공유 페이지 400 상태 에러일 때만 notFound 페이지가 나오도록 수정

# 상세 설명

BlocksViewerSkeleton 안에서 사용되는 useQuery가 해결되지 않는 문제를 해결함

https://github.com/JoberChipFrappuccino/joberchip-fe-refactoring/blob/be32a85e5bdc11efabd594c519b6e0ad7bdd0d3b/src/pages/Share/index.tsx#L35-L50



