### PR TITLE
공유 페이지 접근 권한 문제 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react'
 import { Outlet } from 'react-router-dom'
 import { ToastContainer } from 'react-toastify'
 import styles from './App.module.scss'
+import { NotFoundErrorBoundary } from './components/Common/Errors/NotFoundErrorBoundary'
 
 // import '@/styles/reset.scss'
 import '@/styles/toast.scss'
@@ -16,9 +17,11 @@ export default function App() {
       <ToastContainer />
       <Layout>
         <Layout.Content className={styles.layout}>
-          <Suspense>
-            <Outlet />
-          </Suspense>
+          <NotFoundErrorBoundary>
+            <Suspense>
+              <Outlet />
+            </Suspense>
+          </NotFoundErrorBoundary>
         </Layout.Content>
       </Layout>
     </div>

--- a/src/apis/page.ts
+++ b/src/apis/page.ts
@@ -156,7 +156,7 @@ export interface EditPageBlockBody {
  * @description 페이지 내 블록 위치 / 형태 수정
  * @see https://www.notion.so/954491d9c292452c8fb13fe95280c3d7
  */
-export async function fetchLayout(
+export async function fetchLayoutAPI(
   pageId: string,
   blocks: FetchLayoutBlocksParam[]
 ): Promise<ResponseBase<FetchLayoutResponse>> {

--- a/src/components/Common/Errors/NotFoundErrorBoundary.tsx
+++ b/src/components/Common/Errors/NotFoundErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { isAxiosError } from 'axios'
+import React, { type ErrorInfo, type PropsWithChildren } from 'react'
+
+export type NotFoundErrorBoundaryBaseProps<TError> = PropsWithChildren<{
+  onReset?: () => void
+  caught?: (error: unknown) => error is TError
+}>
+type NotFoundErrorBoundaryProps<TError> = NotFoundErrorBoundaryBaseProps<TError>
+interface NotFoundErrorBoundaryState<TError> {
+  error: TError | Error | null
+}
+
+/**
+ * @note 400번 에러는 NotFound로 처리합니다. {@link https://www.notion.so/72d474ef1cfd45cf81feaade1ce4b9fc}를 참고해주세요
+ */
+export class NotFoundErrorBoundary<TError = Error> extends React.Component<
+  NotFoundErrorBoundaryProps<TError>,
+  NotFoundErrorBoundaryState<TError>
+> {
+  public state: NotFoundErrorBoundaryState<TError> = {
+    error: null
+  }
+
+  constructor(props: NotFoundErrorBoundaryProps<TError>) {
+    super(props)
+    this.state = { error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): NotFoundErrorBoundaryState<Error> {
+    return { error }
+  }
+
+  componentDidCatch(error: unknown, _errorInfo: ErrorInfo) {
+    if (isAxiosError(error)) {
+      error.response?.status === 400 && this.setState({ error })
+      return
+    }
+    throw error
+  }
+
+  render() {
+    if (this.state.error) {
+      if (process.env.NODE_ENV === 'development') console.error('CATCH NOT FOUND ERROR BOUNDARY :', this.state.error)
+      return <h1>NOT FOUND</h1>
+    }
+    return this.props.children
+  }
+}

--- a/src/components/SharePage/DnDViewer/BlocksViewer.tsx
+++ b/src/components/SharePage/DnDViewer/BlocksViewer.tsx
@@ -23,11 +23,13 @@ export const BlocksViewer = () => {
   const [viewModeGrid, setViewModeGrid] = useState(getLayoutByMode(sharePage.children, 'VIEW'))
   const [rowHeight, setRowHeight] = useState(0)
   const [margin, setMargin] = useState(0)
+  const [isChangeLayout, setIsChangeLayout] = useState(false)
 
   const nextLayout = useDebounce(editModeGrid.layouts.lg, LAYOUT_DEBOUNCE_TIME)
 
   useEffect(() => {
     if (mode === 'VIEW') return
+    if (!isChangeLayout) return
     fetchLayout(pageId, convertLayoutToParam(sharePage.children, nextLayout))
   }, [nextLayout])
 
@@ -53,29 +55,26 @@ export const BlocksViewer = () => {
     )
 
   const handleChangeLayout: ResponsiveProps['onLayoutChange'] = //
-    useCallback<NonNullable<ResponsiveProps['onLayoutChange']>>(
-      (layout, _layouts) => {
-        if (mode === 'VIEW') return
-        const changedLayout = sortLayout(layout)
-        if (JSON.stringify(sortLayout(changedLayout)) === JSON.stringify(editModeGrid.layouts.lg)) return // TODO : 비교로직 수정 필요
-        setEditModeGrid(() => ({ breakpoints: 'lg', layouts: { lg: changedLayout } }))
-      },
-      [activeBlockId]
-    )
+    (layout, _layouts) => {
+      if (mode === 'VIEW') return
+      const changedLayout = sortLayout(layout)
+      if (JSON.stringify(sortLayout(changedLayout)) === JSON.stringify(editModeGrid.layouts.lg)) {
+        setIsChangeLayout(false)
+        return
+      }
+      setIsChangeLayout(true)
+      setEditModeGrid(() => ({ breakpoints: 'lg', layouts: { lg: changedLayout } }))
+    }
 
-  const handleOnDragStart: ResponsiveProps['onDragStart'] = //
-    useCallback<NonNullable<ResponsiveProps['onDragStart']>>(
-      (_layout, _oldItem, _newItem, _placeholder, e, el) => {
-        setActiveBlockId(el.id)
-        if (e.type === 'mousedown') return
-        const targetElement = e.target as HTMLElement
-        if (targetElement.id === DROPDOWN_TRIGGER_ICON_ID) {
-          // 컨텍스트가 비워졌을 떄 클릭 이벤트를 실행합니다.
-          setTimeout(() => targetElement.closest('button')?.click())
-        }
-      },
-      [activeBlockId]
-    )
+  const handleOnDragStart: ResponsiveProps['onDragStart'] = (_layout, _oldItem, _newItem, _placeholder, e, el) => {
+    setActiveBlockId(el.id)
+    if (e.type === 'mousedown') return
+    const targetElement = e.target as HTMLElement
+    if (targetElement.id === DROPDOWN_TRIGGER_ICON_ID) {
+      // 컨텍스트가 비워졌을 떄 클릭 이벤트를 실행합니다.
+      setTimeout(() => targetElement.closest('button')?.click())
+    }
+  }
 
   return (
     <div className={styles.layout}>

--- a/src/components/SharePage/DnDViewer/BlocksViewer.tsx
+++ b/src/components/SharePage/DnDViewer/BlocksViewer.tsx
@@ -1,7 +1,6 @@
 import classNames from 'classnames'
 import { useCallback, useEffect, useState } from 'react'
 import { type ResponsiveProps } from 'react-grid-layout'
-import { fetchLayout } from '@/apis/page'
 import { ViewerBox } from '@/components/Common/SwitchCases/ViewerBox'
 import { MainBlockInfo } from '@/components/Common/Ui/MainBlockInfo'
 import { SpaceActionBar } from '@/components/SharePage/ActionBar/SpaceActionBar'
@@ -11,7 +10,6 @@ import { BREAKPOINTS, LAYOUT_DEBOUNCE_TIME } from '@/constants/space'
 import { useSharePageQuery } from '@/hooks/queries/useSharePageQuery'
 import { useBlockActionStore } from '@/store/blockAction'
 import { useSharePageModeStore } from '@/store/sharePage'
-import { to, toast } from '@/utils'
 import { calculateRatio, convertLayoutToParam, getLayoutByMode, sortLayout } from '@/utils/SharePage'
 import { useDebounce } from '@/hooks/useDebounce'
 import styles from './BlocksViewer.module.scss'
@@ -19,7 +17,7 @@ import { ResponsiveGridLayout } from './ResponsiveGridLayout'
 
 export const BlocksViewer = () => {
   const { mode } = useSharePageModeStore()
-  const { sharePage, pageId } = useSharePageQuery()
+  const { sharePage, pageId, fetchLayout } = useSharePageQuery()
   const { activeBlockId, setActiveBlockId } = useBlockActionStore()
   const [editModeGrid, setEditModeGrid] = useState(getLayoutByMode(sharePage.children, 'EDIT'))
   const [viewModeGrid, setViewModeGrid] = useState(getLayoutByMode(sharePage.children, 'VIEW'))
@@ -30,15 +28,7 @@ export const BlocksViewer = () => {
 
   useEffect(() => {
     if (mode === 'VIEW') return
-    if (
-      JSON.stringify(convertLayoutToParam(sharePage.children, nextLayout)) ===
-      JSON.stringify(convertLayoutToParam(sharePage.children, editModeGrid.layouts.lg))
-    ) {
-      return
-    }
-    to(fetchLayout(pageId ?? '', convertLayoutToParam(sharePage.children, nextLayout))).then((res) => {
-      if (res.data) toast('레이아웃이 변경되었습니다', 'success')
-    })
+    fetchLayout(pageId, convertLayoutToParam(sharePage.children, nextLayout))
   }, [nextLayout])
 
   useEffect(() => {

--- a/src/constants/space.ts
+++ b/src/constants/space.ts
@@ -1,4 +1,4 @@
-export const LAYOUT_DEBOUNCE_TIME = 4000
+export const LAYOUT_DEBOUNCE_TIME = 2000
 export const USER_PROFILE_DEBOUNCE_TIME = 2000
 export const BREAKPOINTS = { lg: 1200 }
 

--- a/src/hooks/queries/useSharePageQuery.ts
+++ b/src/hooks/queries/useSharePageQuery.ts
@@ -1,8 +1,10 @@
+import { QueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
-import { getSpaceFromBackAPI } from '@/apis/page'
+import { type FetchLayoutBlocksParam, getSpaceFromBackAPI, fetchLayoutAPI } from '@/apis/page'
 import { SPACE } from '@/constants'
 import { SHARE_PAGE } from '@/constants/querykey'
 import { type SharePage } from '@/models/space'
+import { to, toast } from '@/utils'
 import { useServerSideProps } from '../serverSideProps'
 import { useSuspenseQuery } from './useSuspenseQuery'
 
@@ -10,8 +12,10 @@ type SharePageHook = () => {
   sharePage: SharePage
   isSuccess: boolean
   pageId: string | undefined
+  fetchLayout: (pageId: string | undefined, layout: FetchLayoutBlocksParam[]) => Promise<void>
 }
 export const useSharePageQuery: SharePageHook = () => {
+  const queryClient = new QueryClient()
   const { source, isServerSide } = useServerSideProps<SharePage>(SPACE)
   const { pageId } = useParams()
   const { data, ...rest } = useSuspenseQuery([SHARE_PAGE, pageId], () => {
@@ -19,5 +23,15 @@ export const useSharePageQuery: SharePageHook = () => {
     return getSpaceFromBackAPI(pageId ?? '')
   })
 
-  return { sharePage: data, pageId, ...rest }
+  const fetchLayout = async (pageId: string | undefined, layout: FetchLayoutBlocksParam[]) => {
+    if (!pageId) return toast('잘못된 접근입니다.', 'error')
+    const res = await to(fetchLayoutAPI(pageId, layout))
+    if (res.status === 'success') {
+      toast(res.message, res.status)
+    } else {
+      toast(res.message, res.status)
+      queryClient.fetchQuery([SHARE_PAGE, pageId], () => getSpaceFromBackAPI(pageId))
+    }
+  }
+  return { sharePage: data, pageId, fetchLayout, ...rest }
 }

--- a/src/hooks/serverSideProps.ts
+++ b/src/hooks/serverSideProps.ts
@@ -4,7 +4,6 @@ import { ServerSideContext } from '@/contexts/SSRContext'
 
 function useServerSideProps(): { isServerSide: boolean }
 function useServerSideProps<T>(key: string): { isServerSide: boolean; source: T }
-// eslint-disable-next-line @typescript-eslint/no-redeclare
 function useServerSideProps<T>(key?: string) {
   const [isServerSide, setIsServerSide] = useState(typeof window === 'undefined')
   const ctx = useContext(ServerSideContext)


### PR DESCRIPTION
# 요약

클라이언트에서 공유 페이지 정보에 접근하지 못할 경우 notFound를 처리하는 에러 바운더리를 추가했습니다.

# 상세 설명

공유 페이지에서 400 에러를 반환할 경우 해당 페이지 페이지 접근 권한이 없다고 판단하여 notFound 처리합니다.

(페이지가 존재하지 않을 경우는 프론트 서버에서 notFound 페이지를 클라이언트로 전송합니다.)

https://github.com/JoberChipFrappuccino/joberchip-fe-refactoring/blob/71d53ce3fbf6b4f3e3362ca66364f604c3addf1e/src/components/Common/Errors/NotFoundErrorBoundary.tsx#L16-L40