### PR TITLE
자동 저장이 안되는 문제 수정

### DIFF
--- a/src/components/SharePage/DnDViewer/BlocksViewer.tsx
+++ b/src/components/SharePage/DnDViewer/BlocksViewer.tsx
@@ -23,13 +23,11 @@ export const BlocksViewer = () => {
   const [viewModeGrid, setViewModeGrid] = useState(getLayoutByMode(sharePage.children, 'VIEW'))
   const [rowHeight, setRowHeight] = useState(0)
   const [margin, setMargin] = useState(0)
-  const [isChangeLayout, setIsChangeLayout] = useState(false)
 
   const nextLayout = useDebounce(editModeGrid.layouts.lg, LAYOUT_DEBOUNCE_TIME)
 
   useEffect(() => {
     if (mode === 'VIEW') return
-    if (!isChangeLayout) return
     fetchLayout(pageId, convertLayoutToParam(sharePage.children, nextLayout))
   }, [nextLayout])
 
@@ -59,10 +57,8 @@ export const BlocksViewer = () => {
       if (mode === 'VIEW') return
       const changedLayout = sortLayout(layout)
       if (JSON.stringify(sortLayout(changedLayout)) === JSON.stringify(editModeGrid.layouts.lg)) {
-        setIsChangeLayout(false)
         return
       }
-      setIsChangeLayout(true)
       setEditModeGrid(() => ({ breakpoints: 'lg', layouts: { lg: changedLayout } }))
     }
 

--- a/src/components/SpacePage/UserProfile.tsx
+++ b/src/components/SpacePage/UserProfile.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { createSpaceAPI } from '@/apis/space'
 import { SPACE_LIST } from '@/constants/querykey'
 import { useSpaceListQuery } from '@/hooks/queries/useSpaceListQuery'
@@ -13,7 +13,6 @@ export function UserProfile() {
   const { signOut } = useAuth()
   const { spaceList } = useSpaceListQuery()
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
 
   const handleOnClickCreateSpace = () => {
     createSpaceAPI()
@@ -45,7 +44,7 @@ export function UserProfile() {
           type="button"
           onClick={() => {
             signOut()
-            navigate('/signin')
+            location.reload()
           }}
         >
           로그아웃

--- a/src/hooks/queries/useSharePageQuery.ts
+++ b/src/hooks/queries/useSharePageQuery.ts
@@ -26,12 +26,11 @@ export const useSharePageQuery: SharePageHook = () => {
   const fetchLayout = async (pageId: string | undefined, layout: FetchLayoutBlocksParam[]) => {
     if (!pageId) return toast('잘못된 접근입니다.', 'error')
     const res = await to(fetchLayoutAPI(pageId, layout))
-    if (res.status === 'success') {
-      toast(res.message, res.status)
-    } else {
+    if (res.status !== 'success') {
       toast(res.message, res.status)
       queryClient.fetchQuery([SHARE_PAGE, pageId], () => getSpaceFromBackAPI(pageId))
     }
   }
+
   return { sharePage: data, pageId, fetchLayout, ...rest }
 }


### PR DESCRIPTION
# 요약

다음 에러를 수정했습니다.

- #21 

에러 수정 중 로그아웃시 react-query의 캐시가 남아있는 

문제가 발견되어 useNavigate을 window.reload로 변경했습니다.