### PR TITLE
Edit 모드일 경우 케밥 매뉴가 사라지는 문제 수정

### DIFF
--- a/src/components/SharePage/Blocks/LinkBlock/LinkBlock.module.scss
+++ b/src/components/SharePage/Blocks/LinkBlock/LinkBlock.module.scss
@@ -18,19 +18,24 @@
       padding: 1rem;
       .titleUrl {
         display: flex;
-        max-width: 12.5rem;
         overflow: hidden;
         padding-top: 0.1875rem;
         margin-left: 1.25rem;
         flex-direction: column;
         span {
-          display: flex;
+          display: inline-block;
           font-weight: 700;
           font-size: 1.6rem;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
         a {
           color: #c9c9c9;
           font-size: 1.3rem;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
           &:hover {
             color: #4c61ff;
           }
@@ -50,10 +55,9 @@
   outline: none;
   display: flex;
   cursor: pointer;
-  height: 3.125rem;
+  min-height: 3.125rem;
   background-color: black;
   justify-content: space-between;
-
   .footerLeft {
     height: 100%;
     display: flex;

--- a/src/components/SharePage/Profile/ProfileSwitchCase.tsx
+++ b/src/components/SharePage/Profile/ProfileSwitchCase.tsx
@@ -1,5 +1,4 @@
-import { Suspense } from 'react'
-import { ErrorBoundary } from 'react-error-boundary'
+import { useSharePageQuery } from '@/hooks/queries/useSharePageQuery'
 import { useSharePageModeStore } from '@/store/sharePage'
 import ProfileDropDownMenu from './ProfileDropDownMenu'
 import ProfileEditMode from './ProfileEditMode'
@@ -8,21 +7,13 @@ import ProfileViewMode from './ProfileViewMode'
 
 export default function ProfileSwitchCase() {
   const { mode } = useSharePageModeStore()
-
+  const { sharePage } = useSharePageQuery()
   return (
     <div className={styles.container}>
       <div className={styles.profile}>{switchProfileWithMode(mode)}</div>
-      {mode === 'EDIT' && (
-        <Suspense>
-          <ProfileDropDownMenu />
-        </Suspense>
-      )}
+      {sharePage.privilege === 'EDIT' && <ProfileDropDownMenu />}
     </div>
   )
-}
-
-function NullComponent() {
-  return null
 }
 
 function switchProfileWithMode(mode: string) {
@@ -30,11 +21,7 @@ function switchProfileWithMode(mode: string) {
     case 'VIEW':
       return <ProfileViewMode />
     case 'EDIT':
-      return (
-        <ErrorBoundary fallback={<NullComponent />}>
-          <ProfileEditMode />
-        </ErrorBoundary>
-      )
+      return <ProfileEditMode />
     default:
       if (process.env.NODE_ENV === 'development') throw new Error("ProfileSwitchCase: mode is not 'VIEW' or 'EDIT'")
       return null

--- a/src/components/SharePage/Profile/ProfileViewMode.module.scss
+++ b/src/components/SharePage/Profile/ProfileViewMode.module.scss
@@ -38,8 +38,14 @@
       font-weight: bold;
       margin: 0;
       margin-bottom: 1rem;
+      font-size: 3rem;
+      font-weight: bold;
+      background-color: white;
     }
     p {
+      font-size: 1.6rem;
+      // color: grey;
+      // background-color: white;
       color: grey;
       margin: 0;
     }

--- a/src/components/SharePage/Profile/ProfileViewMode.tsx
+++ b/src/components/SharePage/Profile/ProfileViewMode.tsx
@@ -9,8 +9,8 @@ export default function ProfileViewMode() {
         <img src={sharePage?.profileImageLink} alt={`${sharePage.title} thumbnail`} />
       </div>
       <div className={styles.profileCover}>
-        <h2>{sharePage.title}</h2>
-        <p>{sharePage.description}</p>
+        <h2 className={styles.title}>{sharePage.title}</h2>
+        <p className={styles.description}>{sharePage.description}</p>
       </div>
     </div>
   )


### PR DESCRIPTION
# 요약

페이지 편집 권한이 있는 경우지만, Edit 모드일 경우 프로파일의 케밥 매뉴가 사라지는 문제를 수정했습니다.
- #23 

추가로 링크 블럭 텍스트 overflow가 ellipsis 되도록 스타일을 수정되었습니다.
 